### PR TITLE
防止出现没有写权限的错误

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
 var fs = require('fs');
+var os = require('os');
 
 var exists = fs.exists || fs.access;
 var existsSync = fs.existsSync || fs.accessSync;
 
 var path2fmpp = path.join(__dirname, './libs/bin/fmpp' + (process.platform === 'win32' ? '.bat' : ''));
-var tmpDir = path.join(__dirname, '/./tmp/');
+var tmpDir = os.tmpdir();
 
 module.exports = function() {
   removeCache(tmpDir);


### PR DESCRIPTION
如果用户使用sudo安装，那么该包所处的文件夹普通用户很有可能是没有写权限。使用os包下的tmpdir函数能够避免该问题。